### PR TITLE
support aarch64-pc-windows-msvc (fixes #10)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,38 +1,53 @@
 environment:
   global:
+    HOST: x86_64-pc-windows-msvc
     RUST_VERSION: stable
     CRATE_NAME: remove_dir_all
   matrix:
     # MinGW
     - TARGET: i686-pc-windows-gnu
+      HOST: i686-pc-windows-gnu
     - TARGET: x86_64-pc-windows-gnu
+      HOST: x86_64-pc-windows-gnu
 
     # MSVC
     - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
+    - TARGET: aarch64-pc-windows-msvc
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     # Testing other channels
     # Beta channel
     - TARGET: i686-pc-windows-gnu
+      HOST: i686-pc-windows-gnu
       RUST_VERSION: beta
     - TARGET: x86_64-pc-windows-gnu
+      HOST: x86_64-pc-windows-gnu
       RUST_VERSION: beta
 
     - TARGET: i686-pc-windows-msvc
       RUST_VERSION: beta
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: beta
+    - TARGET: aarch64-pc-windows-msvc
+      RUST_VERSION: beta
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
     # Nightly channel
     - TARGET: i686-pc-windows-gnu
+      HOST: i686-pc-windows-gnu
       RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-gnu
+      HOST: x86_64-pc-windows-gnu
       RUST_VERSION: nightly
 
     - TARGET: i686-pc-windows-msvc
       RUST_VERSION: nightly
     - TARGET: x86_64-pc-windows-msvc
       RUST_VERSION: nightly
+    - TARGET: aarch64-pc-windows-msvc
+      RUST_VERSION: nightly
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 
 matrix:
   allow_failures:
@@ -46,17 +61,22 @@ install:
         $Env:PATH += ';C:\msys64\mingw32\bin'
       }
   - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - rustup-init.exe -y --default-host %HOST% --default-toolchain %RUST_VERSION%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustup target install %TARGET%
   - rustc -Vv
   - cargo -V
+build_script:
+  - cargo build --target %TARGET% &&
+    cargo build --target %TARGET% --release
 # TODO This is the "test phase", tweak it as you see fit
 test_script:
-  # we don't run the "test phase" when doing deploys
+  # we don't run the "test phase" when doing deploys, nor do we run it
+  # when the target is aarch64-pc-windows-msvc, since the Appveyor image
+  # can't execute that target's executables
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release
+      if not [%TARGET%]==[aarch64-pc-windows-msvc] (
+        cargo test --target %TARGET% &&
+        cargo test --target %TARGET% --release
+      )
     )
-build: false

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -24,9 +24,11 @@ struct RmdirContext<'a> {
 /// ```rust
 /// extern crate remove_dir_all;
 ///
+/// use std::fs;
 /// use remove_dir_all::*;
 ///
 /// fn main() {
+///     fs::create_dir("./temp/").unwrap();
 ///     remove_dir_all("./temp/").unwrap();
 /// }
 /// ```
@@ -166,9 +168,9 @@ fn move_item(file: &File, ctx: &mut RmdirContext) -> io::Result<()> {
 fn rename(file: &File, new: &Path, replace: bool) -> io::Result<()> {
     // &self must be opened with DELETE permission
     use std::iter;
-    #[cfg(target_arch = "x86")]
+    #[cfg(target_pointer_width = "32")]
     const STRUCT_SIZE: usize = 12;
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_pointer_width = "64")]
     const STRUCT_SIZE: usize = 20;
 
     // FIXME: check for internal NULs in 'new'


### PR DESCRIPTION
This fixes the issue in #10 by selecting a `STRUCT_SIZE` const definition based on `cfg(target_pointer_width)` rather than `cfg(target_arch)`, which is similar to what @froydnj did in for winapi-rs in https://github.com/retep998/winapi-rs/pull/677.

It also adds building (but not testing) of aarch64-pc-windows-msvc to the appveyor.yml configuration. I don't know how to test that target on Appveyor, but we can at least confirm that it builds.

(I'm also testing this fix in Firefox, which failed without the fix in [this CI run](https://treeherder.mozilla.org/#/jobs?repo=autoland&resultStatus=busted&revision=ce509bb0895aac04378f959a5c6627fb10b384d8&selectedJob=250978005) and looks like it'll succeed with the fix in [this one](https://treeherder.mozilla.org/#/jobs?repo=try&revision=77d8feb3fc34f56f5cafce29468d46e491b56b11&selectedJob=251052574).)

As @jdm notes in #10, it might be possible to use `mem::size_of()` here, although I don't know enough about this code or that method to feel confident about using it here. In my testing, `mem::size_of::<FILE_RENAME_INFO>()` is 24 on my 64-bit system, while the sum of the sizes of the first three fields of that struct (which is what `STRUCT_SIZE` represents, if I understand the code correctly) is 16; neither of which is the current hardcoded value of `STRUCT_SIZE` for 64-bit builds (20).

The last fix in this branch is to the example in the comment at the top of fs.rs, which was failing docs tests for me because the "temp" directory that it attempts to remove doesn't exist. I fixed docs tests by adding an `fs::create_dir()` call to create that directory before calling `remove_dir_all()` to remove it.
