### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@
 #[cfg(windows)]
 extern crate winapi;
 
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 #[cfg(windows)]


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.