### PR TITLE
Provide remove_dir_contents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ num_cpus = "1.13"
 rayon = "1.4"
 winapi = {version = "0.3", features = ["std", "errhandlingapi", "winerror", "fileapi", "winbase"]}
 
+[target.'cfg(not(windows))'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 doc-comment = "0.3"
 env_logger = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 
 ## Description
 
-A reliable implementation of `remove_dir_all` for Windows. For Unix systems
-re-exports `std::fs::remove_dir_all`.
+Reliable and fast directory removal functions.
 
-Also provides `remove_dir_contents` for both Windows and Unix.  This
-removes just the contents of the directory, if it exists.
+* `remove_dir_all` - on non-Windows this is a re-export of
+  `std::fs::remove_dir_all`. For Windows an implementation that handles the
+  locking of directories that occurs when deleting directory trees rapidly.
 
-And provides `ensure_e pty_dir` for both Windows and Unix.  This
-creates an empty directory, or deletes the contents of an existing one.
+* `remove_dir_contents` - as for `remove_dir_all` but does not delete the
+  supplied root directory.
+
+* `ensure_empty_dir` - as for `remove_dir_contents` but will create the
+  directory if it does not exist.
 
 ```rust,no_run
 extern crate remove_dir_all;
@@ -22,6 +25,7 @@ use remove_dir_all::*;
 
 fn main() {
     remove_dir_all("./temp/").unwrap();
+    remove_dir_contents("./cache/").unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ re-exports `std::fs::remove_dir_all`.
 Also provides `remove_dir_contents` for both Windows and Unix.  This
 removes just the contents of the directory, if it exists.
 
+And provides `ensure_e pty_dir` for both Windows and Unix.  This
+creates an empty directory, or deletes the contents of an existing one.
+
 ```rust,no_run
 extern crate remove_dir_all;
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 A reliable implementation of `remove_dir_all` for Windows. For Unix systems
 re-exports `std::fs::remove_dir_all`.
 
+Also provides `remove_dir_contents` for both Windows and Unix.  This
+removes just the contents of the directory, if it exists.
+
 ```rust,no_run
 extern crate remove_dir_all;
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -60,8 +60,8 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
     // To handle files with names like `CON` and `morse .. .`,  and when a
     // directory structure is so deep it needs long path names the path is first
     // converted to the Win32 file namespace by calling `canonicalize()`.
-    let path = path.as_ref().canonicalize()?;
-    _delete_dir_contents(&path)?;
+
+    let path = _remove_dir_contents(path)?;
     let metadata = path.metadata()?;
     if metadata.permissions().readonly() {
         delete_readonly(metadata, &path)?;
@@ -74,6 +74,13 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
         log::trace!("removed {}", &path.display());
     }
     Ok(())
+}
+
+/// Returns the canonicalised path, for one of caller's convenience.
+pub fn _remove_dir_contents<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+    let path = path.as_ref().canonicalize()?;
+    _delete_dir_contents(&path)?;
+    Ok(path)
 }
 
 fn _delete_dir_contents(path: &PathBuf) -> io::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,9 @@ doctest!("../README.md");
 #[cfg(windows)]
 mod fs;
 
+#[cfg(not(windows))]
+mod unix;
+
 #[cfg(windows)]
 pub use self::fs::remove_dir_all;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 //! This library provides a reliable implementation of `remove_dir_all` for Windows.
 //! For Unix systems, it re-exports `std::fs::remove_dir_all`.
 //!
-//! It also provides `remove_dir_contents` for both Unix and Windows.
+//! It also provides `remove_dir_contents` and `ensure_empty_dir`
+//! for both Unix and Windows.
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
@@ -32,4 +33,5 @@ pub use self::fs::remove_dir_all;
 #[cfg(not(windows))]
 pub use std::fs::remove_dir_all;
 
+pub use portable::ensure_empty_dir;
 pub use portable::remove_dir_contents;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! This library provides a reliable implementation of `remove_dir_all` for Windows.
 //! For Unix systems, it re-exports `std::fs::remove_dir_all`.
+//!
+//! It also provides `remove_dir_contents` for both Unix and Windows.
 
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
@@ -22,8 +24,12 @@ mod fs;
 #[cfg(not(windows))]
 mod unix;
 
+mod portable;
+
 #[cfg(windows)]
 pub use self::fs::remove_dir_all;
 
 #[cfg(not(windows))]
 pub use std::fs::remove_dir_all;
+
+pub use portable::remove_dir_contents;

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -18,3 +18,43 @@ pub fn remove_dir_contents<P: AsRef<Path>>(path: P) -> io::Result<()> {
     _remove_dir_contents(path)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod test {
+    use tempfile::TempDir;
+    use crate::remove_dir_all;
+    use crate::remove_dir_contents;
+    use std::fs::{self, File};
+    use std::io;
+
+    fn expect_failure<T>(k: io::ErrorKind, r: io::Result<T>) -> io::Result<()> {
+        match r {
+            Err(e) if e.kind() == k => Ok(()),
+            Err(e) => Err(e),
+            Ok(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "unexpected success".to_string(),
+            )),
+        }
+    }
+
+    #[test]
+    fn mkdir_rm() -> Result<(), io::Error> {
+        let tmp = TempDir::new()?;
+        let ours = tmp.path().join("t.mkdir");
+        let file = ours.join("file");
+        fs::create_dir(&ours)?;
+        File::create(&file)?;
+        File::open(&file)?;
+
+        expect_failure(io::ErrorKind::Other, remove_dir_contents(&file))?;
+
+        remove_dir_contents(&ours)?;
+        expect_failure(io::ErrorKind::NotFound, File::open(&file))?;
+
+        remove_dir_contents(&ours)?;
+        remove_dir_all(&ours)?;
+        expect_failure(io::ErrorKind::NotFound, remove_dir_contents(&ours))?;
+        Ok(())
+    }
+}

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -1,0 +1,20 @@
+use std::io;
+use std::path::Path;
+
+#[cfg(windows)]
+use crate::fs::_remove_dir_contents;
+
+#[cfg(not(windows))]
+use crate::unix::_remove_dir_contents;
+
+/// Deletes the contents of `dir_path`, but not the directory iteself.
+///
+/// If `dir_path` is a symlink to a directory, deletes the contents
+/// of that directory.  Fails if `dir_path` does not exist.
+pub fn remove_dir_contents<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    // This wrapper function exists because the core function
+    // for Windows, in crate::fs, returns a PathBuf, which our
+    // caller shouldn't see.
+    _remove_dir_contents(path)?;
+    Ok(())
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+fn remove_file_or_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+    match fs::remove_file(&path) {
+        // Unfortunately, there is no ErrorKind for EISDIR
+        Err(e) if e.raw_os_error() == Some(libc::EISDIR) =>
+            fs::remove_dir_all(&path),
+        r => r,
+    }
+}
+
+pub fn _remove_dir_contents<P: AsRef<Path>>(path: P) -> Result<(), io::Error> {
+    for entry in fs::read_dir(path)? {
+        let entry_path = entry?.path();
+        remove_file_or_dir_all(&entry_path)?;
+    }
+
+    Ok(())
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::fs;
 use std::io;
 use std::path::Path;


### PR DESCRIPTION
Hi.

Apropos of https://github.com/rust-lang/rustup/issues/2433 @rbtcollins suggested putting the `remove_dir_contents` function here in `remove_dir_all`.

I think I have done the right thing in the Windows code in `fs.rs` <strike>but I have not been able to test, or even compile, the Windows code at all because I have no Windows installs</strike>.  _Edit: the CI tests seem to pass so I think it is probably right..._

I did provide a test case for my new code.

I hope this meets with your approval.  Let me know what you think.

Regards,
Ian.