### PR TITLE
Fix license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version](https://img.shields.io/crates/v/remove_dir_all.svg)](https://crates.io/crates/remove_dir_all)
 [![Docs](https://docs.rs/remove_dir_all/badge.svg)](https://docs.rs/remove_dir_all)
-[![License](https://img.shields.io/github/license/XAMPPRocky/remove_dir_all.svg)](https://github.com/XAMPPRocky/remove_dir_all)
+[![License](https://img.shields.io/crates/l/remove_dir_all.svg)](https://github.com/XAMPPRocky/remove_dir_all)
 
 ## Description
 


### PR DESCRIPTION
GitHub does not support converting multiple license files to a license identifier, so uses crates.io badge instead.

before:
![License](https://img.shields.io/github/license/XAMPPRocky/remove_dir_all.svg)
after:
![License](https://img.shields.io/crates/l/remove_dir_all.svg)