### PR TITLE
Fix: On Macos subdirectories are not deleted, instead it errors with PermissionDenied

### DIFF
--- a/src/portable.rs
+++ b/src/portable.rs
@@ -96,9 +96,14 @@ mod test {
         let tmp = TempDir::new()?;
         let ours = tmp.path().join("t.mkdir");
         let file = ours.join("file");
+        let subdir = ours.join("subdir");
+        let fileinsubdir = subdir.join("anotherfile");
         fs::create_dir(&ours)?;
+        fs::create_dir(&subdir)?;
         File::create(&file)?;
         File::open(&file)?;
+        File::create(&fileinsubdir)?;
+        File::open(&fileinsubdir)?;
         Ok(Prep { _tmp: tmp, ours, file })
     }
 


### PR DESCRIPTION
On Macos trying to `unlink()` a directory results in `EPERM` not `EISDIR` causing the check in https://github.com/XAMPPRocky/remove_dir_all/blob/9b164cecdb4a0590af68be8b22f9c747402237e3/src/unix.rs#L8 to fail. This happens whenever the directory passed to `ensure_empty_dir()` or `remove_dir_contents()` contains a subdirectory.

This PR fixes that and also:
* Fixes the tests to work on current stable/beta/nightly (I can put that in a separate PR on request.)
* Creates a subdirectory with another file in the test setup.

Once done, this will fix #35.