### PR TITLE
Remove nightly feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo build --verbose --target ${{ matrix.arch }}-pc-windows-${{ matrix.variant }}
       - name: Run tests (nightly)
         if: (matrix.arch != 'aarch64') && (matrix.channel == 'nightly')
-        run: cargo test --verbose --target ${{ matrix.arch }}-pc-windows-${{ matrix.variant }} --features nightly
+        run: cargo test --verbose --target ${{ matrix.arch }}-pc-windows-${{ matrix.variant }}
       - name: Run tests
         if: (matrix.arch != 'aarch64') && (matrix.channel != 'nightly')
         run: cargo test --verbose --target ${{ matrix.arch }}-pc-windows-${{ matrix.variant }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ version = "0.7.1-alpha.0"
 
 [features]
 default = []
-nightly = []
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! It also provides `remove_dir_contents` and `ensure_empty_dir`
 //! for both Unix and Windows.
 
-#![cfg_attr(feature = "nightly", feature(io_error_more))]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(rust_2018_idioms)]


### PR DESCRIPTION
We no longer need the io_error_more feature from nightly.