### PR TITLE
Migrate from winapi to windows-sys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased
 
 - Added feature to enable use of rayon.
+- Migrated from winapi to windows-sys
 
 # 0.5.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ cfg-if = "1.0.0"
 log = "0.4.11"
 num_cpus = { version = "1.13", optional = true }
 rayon = { version = "1.4", optional = true }
-winapi = { version = "0.3", features = [
-  "std",
-  "errhandlingapi",
-  "winerror",
-  "fileapi",
-  "winbase",
-] }
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Storage_FileSystem",
+    "Win32_System_SystemServices",
+]
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"

--- a/src/portable.rs
+++ b/src/portable.rs
@@ -49,8 +49,8 @@ mod test {
 
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
-            const ENOTDIR:i32 = winapi::shared::winerror::ERROR_DIRECTORY as i32;
-            const ENOENT:i32 = winapi::shared::winerror::ERROR_FILE_NOT_FOUND as i32;
+            const ENOTDIR:i32 = windows_sys::Win32::Foundation::ERROR_DIRECTORY as i32;
+            const ENOENT:i32 = windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND as i32;
         } else {
             const ENOTDIR:i32 = libc::ENOTDIR;
             const ENOENT:i32 = libc::ENOENT;


### PR DESCRIPTION
This PR migrates remove-dir-all from winapi to windows-sys.

Windows-sys is actively maintained, by Microsoft, and has recently
started to be adopted in the ecosystem; mio, parking_lot, wasmtime,
and others have moved to windows-sys.