### PR TITLE
Remove unused `num_cpus` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,13 @@ version = "0.7.1-alpha.0"
 
 [features]
 default = ["parallel"]
-parallel = ["num_cpus", "rayon"]
+parallel = ["rayon"]
 
 [dependencies]
 cfg-if = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 log = "0.4.11"
-num_cpus = { version = "1.13", optional = true }
 rayon = { version = "1.4", optional = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
`remove_dir_all` depends on `num_cpus`, but never invokes it
