### PR TITLE
Regular tests should try to remove a directory too

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,9 @@ mod tests {
         let tmp = TempDir::new()?;
         let ours = tmp.path().join("t.mkdir");
         let file = ours.join("file");
+        let nested = ours.join("another_dir");
         fs::create_dir(&ours)?;
+        fs::create_dir(&nested)?;
         File::create(&file)?;
         File::open(&file)?;
         Ok(Prep {


### PR DESCRIPTION
In the discussion for #35 and #36 it was requested that there was a standalone test that causes this to fail. This adds a directory under the removal target that should be removed. On illumos this fails in a way that I'd expect it to fail for Mac OS:

```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/lib.rs (target/debug/deps/remove_dir_all-c096c2067575cec1)

running 2 tests
Error: Os { code: 1, kind: PermissionDenied, message: "Not owner" }
Error: Os { code: 1, kind: PermissionDenied, message: "Not owner" }
test portable::test::mkdir_rm ... FAILED
test portable::test::ensure_rm ... FAILED

failures:

---- portable::test::mkdir_rm stdout ----
thread 'portable::test::mkdir_rm' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/897e37553bba8b42751c67658967889d11ecd120/library/test/src/lib.rs:184:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- portable::test::ensure_rm stdout ----
thread 'portable::test::ensure_rm' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/897e37553bba8b42751c67658967889d11ecd120/library/test/src/lib.rs:184:5


failures:
    portable::test::ensure_rm
    portable::test::mkdir_rm

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `--lib`
```

I'm not expecting this to be merged as it, but wanted to help speed along getting a fix into #35 and #36 so it can eventually make its way into rustup where I stumbled across this.