### PR TITLE
Update publish-action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,24 +16,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@master
-
-      # Use caching to speed up your build
-      - name: Cache publish-action bin
-        id: cache-publish-action
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-publish-action
         with:
-          path: ~/.cargo
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-v0.1.13
-
-      # install publish-action by cargo in github action
-      - name: Install publish-action
-        if: steps.cache-publish-action.outputs.cache-hit != 'true'
-        run: cargo install publish-action --version=0.1.13
-
-      - name: Publish to cargo
-        run: publish-action
+          # get git tags info
+          fetch-depth: 0
+      
+      - name: Run publish-action
+        uses: tu6ge/publish-action@0.4.5
         env:
           # This can help you tagging the github repository
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It looks like the old publish-action version is broken so update to the latest. Note that it now has a proper github action so we don't have to manually do so much. See https://github.com/tu6ge/publish-action.