### PR TITLE
fix ENXIO

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+MD024:
+  siblings_only: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@
   with `unlink_at` rather than propagating an error. Fixes removal of
   directories containing Unix-domain sockets. (#82)
 
+# 1.0.0
+
+## New features
+
+- New `Builder` and `Remover` structs provide a configurable API for
+  controlling parallel deletion at runtime, exposed via the `remove_dir_all`
+  crate root and the `remove-dir-all` CLI binary. (#80)
+
+## Other changes
+
+- macOS: parallel deletion is now disabled by default due to a global kernel
+  lock in APFS that causes thrashing when `readdir` runs concurrently across
+  threads. Parallelism can still be enabled explicitly via `Builder`. (#80)
+
+# 0.8.4
+
+## Bug fixes
+
+- Unix: correctly detect symlinks on FreeBSD (`EMLINK`) and NetBSD (`EFTYPE`),
+  which do not use `ELOOP` in response to `O_NOFOLLOW`. (#76)
+
+# 0.8.3
+
+## Other changes
+
+- Windows: simplified implementation using `fs_at`'s unified deletion path;
+  removed significant internal dead code. (#72)
+
+# 0.8.2
+
+## New features
+
+- `RemoveDir` trait is now public. (#59)
+- Added `remove-dir-all` CLI binary (opt-in via the `cli` Cargo feature). (#61)
+
+## Bug fixes
+
+- Windows: use `fs_at`'s POSIX-deletion support to correctly handle in-use
+  files on Windows, fixing #34. (#64)
+
+## Other changes
+
+- Improved crate documentation. (#58)
+
 # 0.8.1
 
 ## Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# Changelog
 
-## Bug fixes
+## Unreleased
+
+### Bug fixes
 
 - Unix: `open_dir_at` errors other than symlink-detection (`ELOOP`/`EMLINK`/
   `EFTYPE`) that indicate a non-directory entry — specifically `ENXIO` (returned
@@ -9,59 +11,59 @@
   with `unlink_at` rather than propagating an error. Fixes removal of
   directories containing Unix-domain sockets. (#82)
 
-# 1.0.0
+## 1.0.0
 
-## New features
+### New features
 
 - New `Builder` and `Remover` structs provide a configurable API for
   controlling parallel deletion at runtime, exposed via the `remove_dir_all`
   crate root and the `remove-dir-all` CLI binary. (#80)
 
-## Other changes
+### Other changes
 
 - macOS: parallel deletion is now disabled by default due to a global kernel
   lock in APFS that causes thrashing when `readdir` runs concurrently across
   threads. Parallelism can still be enabled explicitly via `Builder`. (#80)
 
-# 0.8.4
+## 0.8.4
 
-## Bug fixes
+### Bug fixes
 
 - Unix: correctly detect symlinks on FreeBSD (`EMLINK`) and NetBSD (`EFTYPE`),
   which do not use `ELOOP` in response to `O_NOFOLLOW`. (#76)
 
-# 0.8.3
+## 0.8.3
 
-## Other changes
+### Other changes
 
 - Windows: simplified implementation using `fs_at`'s unified deletion path;
   removed significant internal dead code. (#72)
 
-# 0.8.2
+## 0.8.2
 
-## New features
+### New features
 
 - `RemoveDir` trait is now public. (#59)
 - Added `remove-dir-all` CLI binary (opt-in via the `cli` Cargo feature). (#61)
 
-## Bug fixes
+### Bug fixes
 
 - Windows: use `fs_at`'s POSIX-deletion support to correctly handle in-use
   files on Windows, fixing #34. (#64)
 
-## Other changes
+### Other changes
 
 - Improved crate documentation. (#58)
 
-# 0.8.1
+## 0.8.1
 
-## Other changes
+### Other changes
 
 - Fix use of fcntl, missing undocumented extra argument.
 
-# 0.8.0
+## 0.8.0
 
-## Security changes
+### Security changes
 
 - Fix TOCTOU race conditions both inside the implementation of functions and the
   contract: functions now only operate on directories. Callers wanting to
@@ -120,37 +122,37 @@
   functions cannot assume anything about the particular threat model of a
   program and must err on the side of caution.
 
-## Other changes
+### Other changes
 
 - Made feature to control use of rayon off-by-default for easier integration by
   other crates.
 
-# 0.7.0
+## 0.7.0
 
 - add remove_dir_contents and ensure_empty_dir
 
-# 0.6.1
+## 0.6.1
 
 - update author
 - update README.md
 
-# 0.6.0
+## 0.6.0
 
 - Added threaded deletion on windows
 - requires edition 2018 to build
 
-# 0.5.3
+## 0.5.3
 
 - lints and doc fixes
 
-# 0.5.2
+## 0.5.2
 
 - Added support for `aarch64-pc-windows-msvc`.
 
-# 0.5.1
+## 0.5.1
 
 - Fixed deletion of readonly items.
 
-# 0.5.0
+## 0.5.0
 
 - Upgraded to winapi 0.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+## Bug fixes
+
+- Unix: `open_dir_at` errors other than symlink-detection (`ELOOP`/`EMLINK`/
+  `EFTYPE`) that indicate a non-directory entry — specifically `ENXIO` (returned
+  when opening an `AF_UNIX` socket) and `ENOTDIR` (returned when `O_DIRECTORY`
+  is in effect) — are now treated as "not a directory" and the entry is removed
+  with `unlink_at` rather than propagating an error. Fixes removal of
+  directories containing Unix-domain sockets. (#82)
+
 # 0.8.1
 
 ## Other changes

--- a/src/_impl.rs
+++ b/src/_impl.rs
@@ -180,8 +180,9 @@ fn scan_and_remove_entry_recursively<I: io::Io>(
             .follow(false);
         let child_result = opts.open_dir_at(dirfd, name);
         let is_dir = match child_result {
-            // We expect is_eloop to be the only error
-            Err(e) if !I::is_eloop(&e) => return Err(e),
+            // Errors indicating a non-directory entry (symlink, FIFO, socket,
+            // regular file with O_DIRECTORY, etc.) — fall through to unlink_at.
+            Err(e) if !I::is_not_dir_open_error(&e) => return Err(e),
             Err(_) => false,
             Ok(child_file) => {
                 let metadata = child_file.metadata()?;

--- a/src/_impl/io.rs
+++ b/src/_impl/io.rs
@@ -16,6 +16,9 @@ pub(crate) trait Io {
     #[allow(dead_code)]
     fn unique_identifier(d: &File) -> io::Result<Self::UniqueIdentifier>;
 
+    /// Returns true if the error from `open_dir_at` indicates the entry is not
+    /// a directory (e.g. symlink, FIFO, socket, regular file) and should be
+    /// removed with `unlink_at` instead.
     #[cfg(not(windows))]
-    fn is_eloop(e: &io::Error) -> bool;
+    fn is_not_dir_open_error(e: &io::Error) -> bool;
 }

--- a/src/_impl/unix.rs
+++ b/src/_impl/unix.rs
@@ -34,20 +34,25 @@ impl Io for UnixIo {
         todo!()
     }
 
-    fn is_eloop(e: &io::Error) -> bool {
-        // When the `NO_FOLLOW` flag is set, POSIX specifies that ELOOP be turned
-        // if the trailing component is a symlink.
-        // However, not all platforms follow POSIX on this.
-        //
-        // FreeBSD uses EMLINK: https://man.freebsd.org/cgi/man.cgi?query=open&sektion=2&n=1#end
-        // NetBSD uses EFTYPE: https://man.netbsd.org/open.2#ERRORS
+    fn is_not_dir_open_error(e: &io::Error) -> bool {
+        // ENOTDIR: open_dir_at returned O_DIRECTORY rejection — entry is not a directory.
+        // ENXIO: AF_UNIX sockets return this when opened with O_RDONLY.
+        // ELOOP: O_NOFOLLOW on a symlink. POSIX specifies ELOOP, but some
+        //   platforms differ:
+        //   FreeBSD uses EMLINK: https://man.freebsd.org/cgi/man.cgi?query=open&sektion=2&n=1#end
+        //   NetBSD uses EFTYPE: https://man.netbsd.org/open.2#ERRORS
         cfg_if::cfg_if! {
             if #[cfg(target_os = "freebsd")] {
-                matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::EMLINK))
+                matches!(e.raw_os_error(),
+                    Some(libc::ENOTDIR) | Some(libc::ENXIO) |
+                    Some(libc::ELOOP) | Some(libc::EMLINK))
             } else if #[cfg(target_os = "netbsd")] {
-                matches!(e.raw_os_error(), Some(libc::ELOOP) | Some(libc::EFTYPE))
+                matches!(e.raw_os_error(),
+                    Some(libc::ENOTDIR) | Some(libc::ENXIO) |
+                    Some(libc::ELOOP) | Some(libc::EFTYPE))
             } else {
-                e.raw_os_error() == Some(libc::ELOOP)
+                matches!(e.raw_os_error(),
+                    Some(libc::ENOTDIR) | Some(libc::ENXIO) | Some(libc::ELOOP))
             }
         }
     }


### PR DESCRIPTION
- **Unix: treat ENXIO and ENOTDIR as non-directory in open_dir_at error handling**
- **Add missing CHANGELOG entries for 0.8.2, 0.8.3, 0.8.4, and 1.0.0**
- **Fix MD025: add top-level Changelog heading, demote version headings to H2/H3**
